### PR TITLE
Fix: SignupContent

### DIFF
--- a/DevCamp/Views/Window/SignupView.swift
+++ b/DevCamp/Views/Window/SignupView.swift
@@ -51,10 +51,22 @@ struct SignupView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Username")
-                    TextField("Username", text: $userName)
-                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("@")
+                            .font(.title3)
+                            .bold()
+                            .foregroundColor(.gray)
+                        TextField("Enter username (without @)", text: $userName)
+                            .textFieldStyle(.roundedBorder)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                    .padding(.horizontal, 8)
+                    .frame(height: 44)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(8)
                     Text("Name")
-                    TextField("Name", text: $name)
+                    TextField("Enter name", text: $name)
                         .textFieldStyle(.roundedBorder)
                     Text("About")
                     TextEditor(text: $about)

--- a/DevCamp/Views/Window/SignupView.swift
+++ b/DevCamp/Views/Window/SignupView.swift
@@ -7,7 +7,6 @@ struct SignupView: View {
     @EnvironmentObject private var appState: AppState
     @Environment(\.modelContext) private var modelContext
     
-    @State private var userName: String = ""
     @State private var name: String = ""
     @State private var about: String = ""
     
@@ -50,33 +49,18 @@ struct SignupView: View {
                 Divider()
 
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("Username")
-                    HStack {
-                        Text("@")
-                            .font(.title3)
-                            .bold()
-                            .foregroundColor(.gray)
-                        TextField("Enter username (without @)", text: $userName)
-                            .textFieldStyle(.roundedBorder)
-                            .autocapitalization(.none)
-                            .disableAutocorrection(true)
-                    }
-                    .padding(.horizontal, 8)
-                    .frame(height: 44)
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
                     Text("Name")
                     TextField("Enter name", text: $name)
+                        .frame(width: 400)
                         .textFieldStyle(.roundedBorder)
                     Text("About")
                     TextEditor(text: $about)
-                        .frame(height: 100)
+                        .frame(width: 400, height: 100)
                         .overlay(
                             RoundedRectangle(cornerRadius: 8)
                                 .stroke(Color.gray.opacity(0.5), lineWidth: 1)
                         )
                 }
-                .frame(maxWidth: 600)
                 .padding(.vertical)
             }
             .padding()
@@ -89,7 +73,7 @@ struct SignupView: View {
             Button("Create") {
                 Task {
                     await appState.editUserMetadata(
-                        name: userName,
+                        name: "",
                         about: about,
                         picture: "",
                         nip05: "",


### PR DESCRIPTION
## What you did with this PR
Removed the field to enter a username.

## Background and purpose
When I checked other clients, the format for new registrations is to enter only the name and introduction.

## What you want reviewers to check out
- [ ] The field for entering a user name is missing.

## Screenshots (for screen implementation)
<img width="1470" alt="スクリーンショット 2025-02-14 11 02 06" src="https://github.com/user-attachments/assets/40bcb12f-0d1f-4ad3-96ea-2c64c9eaa9f6" />


