### PR TITLE
Bugfix/relay support nip

### DIFF
--- a/DevCamp/Models/AppState.swift
+++ b/DevCamp/Models/AppState.swift
@@ -339,8 +339,6 @@ class AppState: ObservableObject {
             return
         }
         
-        print("self.selectedOwnerAccount?.publicKey: \(self.selectedOwnerAccount?.publicKey ?? "")")
-        
         var event = Event(
             pubkey: self.selectedOwnerAccount?.publicKey ?? "",
             createdAt: .init(),
@@ -351,11 +349,8 @@ class AppState: ObservableObject {
         
         do {
             try event.sign(with: key)
-            print("event: \(event)")
-            print("nip1relayUrl: \(nip1relayUrl)")
             
             nostrClient.send(event: event, onlyToRelayUrls: [nip1relayUrl])
-            print("Successed to sign or send event")
         } catch {
             print("Failed to sign or send event: \(error)")
         }

--- a/DevCamp/Views/Window/SigninView.swift
+++ b/DevCamp/Views/Window/SigninView.swift
@@ -82,11 +82,6 @@ struct SigninView: View {
         
         if let metadataRelay = Relay.createNew(withUrl: metadataRelayUrl) {
             modelContext.insert(metadataRelay)
-            do {
-                try modelContext.save()
-            } catch {
-                print(error)
-            }
             _ = await metadataRelay.updateRelayInfo()
             
             if !metadataRelay.supportsNip1 {
@@ -97,17 +92,18 @@ struct SigninView: View {
         
         if let nip29Relay = Relay.createNew(withUrl: nip29relayUrl) {
             modelContext.insert(nip29Relay)
-            do {
-                try modelContext.save()
-            } catch {
-                print(error)
-            }
             _ = await nip29Relay.updateRelayInfo()
             
             if !nip29Relay.supportsNip29 {
                 print("NO NIP 29")
                 modelContext.delete(nip29Relay)
             }
+        }
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving Relay: \(error)")
         }
         
         await appState.setupYourOwnMetadata()

--- a/DevCamp/Views/Window/SignupView.swift
+++ b/DevCamp/Views/Window/SignupView.swift
@@ -109,11 +109,6 @@ struct SignupView: View {
         
         if let metadataRelay = Relay.createNew(withUrl: metadataRelayUrl) {
             modelContext.insert(metadataRelay)
-            do {
-                try modelContext.save()
-            } catch {
-                print("Error saving metadataRelay: \(error)")
-            }
             _ = await metadataRelay.updateRelayInfo()
             
             if !metadataRelay.supportsNip1 {
@@ -124,11 +119,6 @@ struct SignupView: View {
         
         if let nip29Relay = Relay.createNew(withUrl: nip29relayUrl) {
             modelContext.insert(nip29Relay)
-            do {
-                try modelContext.save()
-            } catch {
-                print("Error saving nip29Relay: \(error)")
-            }
             _ = await nip29Relay.updateRelayInfo()
             
             if !nip29Relay.supportsNip29 {
@@ -136,7 +126,11 @@ struct SignupView: View {
                 modelContext.delete(nip29Relay)
             }
         }
-        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving Relay: \(error)")
+        }
         await appState.setupYourOwnMetadata()
         await appState.subscribeGroupMetadata()
     }


### PR DESCRIPTION
## What you did with this PR
Avoidance of relays that should have been registered for the group being deactivated

## Background and purpose
I registered a NIP29-compliant relay, but for some reason it was not registered as NIP29-compliant.

## What you want reviewers to check out
- [ ] Whether NIP29-compliant relays are successfully registered when newly registered or logged in

## Screenshots (for screen implementation)
Nothing