### PR TITLE
Fix: Save Account Setting

### DIFF
--- a/DevCamp/Views/Component/Setting/ProfileView.swift
+++ b/DevCamp/Views/Component/Setting/ProfileView.swift
@@ -90,6 +90,8 @@ struct ProfileView: View {
                     Spacer()
                     
                     Button(action: {
+                        appState.profileMetadata?.name = displayName
+                        appState.profileMetadata?.about = about
                         Task{
                             await appState.editUserMetadata(
                                 name: appState.profileMetadata?.name,


### PR DESCRIPTION
## What you did with this PR
When changing and saving account information, the value of the variable that sets the account information is also changed.

## Background and purpose
Previously, when the account settings were saved, they were only saved to the relay. Therefore, when viewing a profile after a screen transition, the changes were not reflected.

## What you want reviewers to check out
- [ ] Profile changes should be reflected after screen transitions.

## Screenshots (for screen implementation)
Nothing
