### PR TITLE
Fix: Listen for user metadata when starting Facetime

### DIFF
--- a/DevCamp/Function/GroupMembers.swift
+++ b/DevCamp/Function/GroupMembers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Nostr
+import NostrClient
 
 func handleGroupMembers(appState: AppState, event: Event, relayUrl: String) {
     let tags = event.tags.map { $0 }
@@ -8,6 +9,8 @@ func handleGroupMembers(appState: AppState, event: Event, relayUrl: String) {
           let groupId = groupTag.otherInformation.first else {
         return
     }
+    
+    print("tags: \(tags)")
     
     let publicKeys = tags.filter { $0.id == "p" }.compactMap { $0.otherInformation.first }
     
@@ -26,6 +29,7 @@ func handleGroupMembers(appState: AppState, event: Event, relayUrl: String) {
             )
             if !appState.allGroupMember.contains(where: { $0.groupId == groupId && $0.publicKey == publicKey }) {
                 appState.allGroupMember.append(member)
+                appState.getMetadataFromPubkey(publicKey: publicKey)
             }
             
             if publicKey == appState.selectedOwnerAccount?.publicKey {

--- a/DevCamp/Function/GroupMembers.swift
+++ b/DevCamp/Function/GroupMembers.swift
@@ -10,8 +10,6 @@ func handleGroupMembers(appState: AppState, event: Event, relayUrl: String) {
         return
     }
     
-    print("tags: \(tags)")
-    
     let publicKeys = tags.filter { $0.id == "p" }.compactMap { $0.otherInformation.first }
     
     DispatchQueue.main.async {

--- a/DevCamp/Function/groupAdmins.swift
+++ b/DevCamp/Function/groupAdmins.swift
@@ -27,6 +27,7 @@ func handleGroupAdmins(appState: AppState, event: Event, relayUrl: String) {
     DispatchQueue.main.async {
         if !appState.allGroupAdmin.contains(where: { $0.groupId == admin.groupId }){
             appState.allGroupAdmin.append(admin)
+            appState.getMetadataFromPubkey(publicKey: publicKey)
         }
     
         if publicKey == appState.selectedOwnerAccount?.publicKey {

--- a/DevCamp/Function/setMetadata.swift
+++ b/DevCamp/Function/setMetadata.swift
@@ -3,6 +3,7 @@ import NostrClient
 import Foundation
 
 func handleSetMetadata(appState: AppState, event: Event) {
+    print("ここもきたぞい")
     if let metadata = decodeUserMetadata(from: event.content) {
         let (name, about, picture, nip05, displayName, website, banner, bot, lud16) = metadata
         

--- a/DevCamp/Function/setMetadata.swift
+++ b/DevCamp/Function/setMetadata.swift
@@ -3,7 +3,6 @@ import NostrClient
 import Foundation
 
 func handleSetMetadata(appState: AppState, event: Event) {
-    print("ここもきたぞい")
     if let metadata = decodeUserMetadata(from: event.content) {
         let (name, about, picture, nip05, displayName, website, banner, bot, lud16) = metadata
         

--- a/DevCamp/Models/AppState.swift
+++ b/DevCamp/Models/AppState.swift
@@ -101,36 +101,7 @@ class AppState: ObservableObject {
         }
     }
     
-//    // MARK: Subscribe to the "Metadata" of the Admins (ideally also Members) of the Group in MetadataRelay
-//    @MainActor
-//    func connectAllMetadataRelays() async {
-//        let relaysDescriptor = FetchDescriptor<Relay>(predicate: #Predicate { $0.supportsNip1 && !$0.supportsNip29 })
-//        guard let metadataRelays = try? modelContainer?.mainContext.fetch(relaysDescriptor) else { return }
-//        var pubkeys = Set<String>()
-//
-//        for admin in self.allGroupAdmin {
-//            pubkeys.insert(admin.publicKey)
-//        }
-//
-//        for member in self.allGroupMember {
-//            pubkeys.insert(member.publicKey)
-//        }
-//        
-//        let pubkeysArray = Array(pubkeys)
-//        
-//        let metadataSubscription = Subscription(
-//            filters: [Filter(authors: pubkeysArray, kinds: [Kind.setMetadata])],
-//            id: IdSubPublicMetadata
-//        )
-//        
-//        let metadataRelayUrls = metadataRelays.map(\.url)
-//        metadataRelayUrls.forEach { metadataRelayUrl in
-//            nostrClient.add(relayWithUrl: metadataRelayUrl, subscriptions: [metadataSubscription] )
-//        }
-//    }
-    
     func getMetadataFromPubkey(publicKey: String) {
-        print("動きます")
         let metadataSubscription = Subscription(
             filters: [Filter(authors: [publicKey], kinds: [Kind.setMetadata])],
             id: IdSubPublicMetadata
@@ -655,10 +626,6 @@ extension AppState: NostrClientDelegate {
                             await subscribeChatMessages()
                             await subscribeGroupAdminAndMembers()
                         }
-//                    case IdSubGroupAdminAndMembers:
-//                        Task{
-//                            await connectAllMetadataRelays()
-//                        }
                     
                     default:
                         ()

--- a/DevCamp/Models/AppState.swift
+++ b/DevCamp/Models/AppState.swift
@@ -101,29 +101,42 @@ class AppState: ObservableObject {
         }
     }
     
-    // MARK: Subscribe to the "Metadata" of the Admins (ideally also Members) of the Group in MetadataRelay
-    @MainActor
-    func connectAllMetadataRelays() async {
-        let relaysDescriptor = FetchDescriptor<Relay>(predicate: #Predicate { $0.supportsNip1 && !$0.supportsNip29 })
-        guard let metadataRelays = try? modelContainer?.mainContext.fetch(relaysDescriptor) else { return }
-        var pubkeys = Set<String>()
-
-        for admin in self.allGroupAdmin {
-            pubkeys.insert(admin.publicKey)
-        }
-
-        for member in self.allGroupMember {
-            pubkeys.insert(member.publicKey)
-        }
-        
-        let pubkeysArray = Array(pubkeys)
-        
+//    // MARK: Subscribe to the "Metadata" of the Admins (ideally also Members) of the Group in MetadataRelay
+//    @MainActor
+//    func connectAllMetadataRelays() async {
+//        let relaysDescriptor = FetchDescriptor<Relay>(predicate: #Predicate { $0.supportsNip1 && !$0.supportsNip29 })
+//        guard let metadataRelays = try? modelContainer?.mainContext.fetch(relaysDescriptor) else { return }
+//        var pubkeys = Set<String>()
+//
+//        for admin in self.allGroupAdmin {
+//            pubkeys.insert(admin.publicKey)
+//        }
+//
+//        for member in self.allGroupMember {
+//            pubkeys.insert(member.publicKey)
+//        }
+//        
+//        let pubkeysArray = Array(pubkeys)
+//        
+//        let metadataSubscription = Subscription(
+//            filters: [Filter(authors: pubkeysArray, kinds: [Kind.setMetadata])],
+//            id: IdSubPublicMetadata
+//        )
+//        
+//        let metadataRelayUrls = metadataRelays.map(\.url)
+//        metadataRelayUrls.forEach { metadataRelayUrl in
+//            nostrClient.add(relayWithUrl: metadataRelayUrl, subscriptions: [metadataSubscription] )
+//        }
+//    }
+    
+    func getMetadataFromPubkey(publicKey: String) {
+        print("動きます")
         let metadataSubscription = Subscription(
-            filters: [Filter(authors: pubkeysArray, kinds: [Kind.setMetadata])],
+            filters: [Filter(authors: [publicKey], kinds: [Kind.setMetadata])],
             id: IdSubPublicMetadata
         )
         
-        let metadataRelayUrls = metadataRelays.map(\.url)
+        let metadataRelayUrls = self.selectedNip1Relays.map(\.url)
         metadataRelayUrls.forEach { metadataRelayUrl in
             nostrClient.add(relayWithUrl: metadataRelayUrl, subscriptions: [metadataSubscription] )
         }
@@ -642,10 +655,10 @@ extension AppState: NostrClientDelegate {
                             await subscribeChatMessages()
                             await subscribeGroupAdminAndMembers()
                         }
-                    case IdSubGroupAdminAndMembers:
-                        Task{
-                            await connectAllMetadataRelays()
-                        }
+//                    case IdSubGroupAdminAndMembers:
+//                        Task{
+//                            await connectAllMetadataRelays()
+//                        }
                     
                     default:
                         ()


### PR DESCRIPTION
## What you did with this PR
Retrieve metadata for the user at the time of acquisition of group members and admins.

## Background and purpose
Only metadata for certain group members and admins was retrieved at build time. Therefore, the metadata of users who joined the group afterwards was not retrieved.

## What you want reviewers to check out
- [ ] Whether the member's display appears correctly when the member enters a Facetime session.

## Screenshots (for screen implementation)
Nothing
