### PR TITLE
Feat: SessionDetailViewからMember, Adminのユーザ情報を確認できる

### DIFF
--- a/DevCamp/Struct/UserMetadata.swift
+++ b/DevCamp/Struct/UserMetadata.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct UserMetadata: Encodable, Hashable {
+struct UserMetadata: Encodable, Hashable, Identifiable {
+    var id: String { publicKey }  // Use publicKey as the unique identifier
     var publicKey: String
     var bech32PublicKey: String
     var name: String?
@@ -14,3 +15,4 @@ struct UserMetadata: Encodable, Hashable {
     var lud16: String?
     var createdAt: Date
 }
+


### PR DESCRIPTION
## What you did with this PR
セッション詳細画面から相手のプロフィールを確認できる

## Background and purpose
現状FaceTimeを開くためのツールとなっている。それ以上の付加価値をつけたい。

## What you want reviewers to check out
- [ ] SessionDetailViewからMember, Adminのプロフィールを確認できる

## Screenshots (for screen implementation)
<img width="1252" alt="スクリーンショット 2025-03-01 15 32 54" src="https://github.com/user-attachments/assets/4c89d5f2-cec3-40d7-b519-5cdb8a60b7e3" />
