### PR TITLE
Fix: セッション説明文が全て表示されない問題の解消

### DIFF
--- a/DevCamp/Views/Window/SessionDetailView.swift
+++ b/DevCamp/Views/Window/SessionDetailView.swift
@@ -86,9 +86,10 @@ struct SessionDetailView: View {
                             .font(.subheadline)
                             .foregroundColor(.gray)
                     }
-                    Text(group.about ?? "")
-                        .font(.body)
-                    
+                    ScrollView {
+                        Text(group.about ?? "")
+                            .font(.body)
+                    }
                 }
                 .padding(.horizontal)
                 


### PR DESCRIPTION
## What you did with this PR
セッション説明文が全て表示されない問題の解消

## Background and purpose

## What you want reviewers to check out

## Screenshots (for screen implementation)
<img width="908" alt="スクリーンショット 2025-03-11 14 24 31" src="https://github.com/user-attachments/assets/cf9756bb-06b5-4738-a2db-3bfee8c32608" />

